### PR TITLE
Fixed incorrect padding of Label305 logo on mobile.

### DIFF
--- a/src/components/sass/sections/work.sass
+++ b/src/components/sass/sections/work.sass
@@ -390,6 +390,8 @@ body
       font-size: 28px
       line-height: 30px
       width: 100%
+    a.label305-logo
+      padding: 0 2px
     p.paragraph
       font-size: 14px
       line-height: 22px !important


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5972653/93710143-9424a980-fb44-11ea-9f7e-8b1dacecf8f2.png)
